### PR TITLE
Working line break in output

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -38,7 +38,7 @@ module.exports =
               # return resolve [] if info.passed
               resolve info.map (error) ->
                 type: error.severity.toLowerCase(),
-                text: [error.hint, "Found: #{error.from}", "Why Not: #{ error.to}"].join "\n"
+                html: [error.hint, "#{error.from} ==>", "#{ error.to}"].join "<br/>"
                 filePath: error.file or filePath,
                 range: [
                   # Atom expects ranges to be 0-based


### PR DESCRIPTION
This commit uses html formatting of messages to show the suggestions
with line breaks. The line breaks make the difference clearly visible.

An example of the output now: http://imgur.com/phNHKwi