### PR TITLE
Restoring Multi-line Error Messages

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -38,7 +38,7 @@ module.exports =
               # return resolve [] if info.passed
               resolve info.map (error) ->
                 type: error.severity.toLowerCase(),
-                html: [error.hint, "#{error.from} ==>", "#{ error.to}"].join "<br/>"
+                text: [error.hint, "#{error.from} ==>", "#{ error.to}"].join "\n"
                 filePath: error.file or filePath,
                 range: [
                   # Atom expects ranges to be 0-based

--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -27,7 +27,8 @@ module.exports =
           json = []
           process = new BufferedProcess
             command: @executablePath
-            args: [filePath, '--json', '--hint=Default', '--hint=Dollar', '--hint=Generalise']
+            # args: [filePath, '--json', '--hint=Default', '--hint=Dollar', '--hint=Generalise']
+            args: [filePath, '--json']
             stdout: (data) ->
               json.push data
             exit: (code) ->
@@ -39,6 +40,7 @@ module.exports =
               resolve info.map (error) ->
                 type: error.severity.toLowerCase(),
                 text: [error.hint, "#{error.from} ==>", "#{ error.to}"].join "\n"
+                # html: [error.hint, "#{error.from} ==>", "#{ error.to}"].join "<br/>"
                 filePath: error.file or filePath,
                 range: [
                   # Atom expects ranges to be 0-based


### PR DESCRIPTION
Hi,

With the latest `atom` and  `linter` the `linter-hlint` was producing odd 
error messages with a `<br>` inside them. Perhaps the latest `linter-1.5.2` 
drops support for `html` messages? (I'm unsure!)

At any rate, replacing the `html` with the `text` field and the `<br>` with 
just `\n` seems to restore the formatting quite nicely.

Thanks!