### PR TITLE
Make hints configurable

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -6,12 +6,21 @@ module.exports =
       title: 'The hlint executable path.'
       type: 'string'
       default: 'hlint'
+    hlintHints:
+      title: 'List of hints to use'
+      type: 'array'
+      default: ['Default', 'Dollar', 'Generalise']
+      items:
+        type: 'string'
 
   activate: ->
     @subscriptions = new CompositeDisposable
     @subscriptions.add atom.config.observe 'linter-hlint.hlintExecutablePath',
       (executablePath) =>
         @executablePath = executablePath
+    @subscriptions.add atom.config.observe 'linter-hlint.hlintHints',
+      (hlintHints) =>
+        @hlintHints = hlintHints
 
   deactivate: ->
     @subscriptions.dispose()
@@ -25,9 +34,11 @@ module.exports =
         return new Promise (resolve, reject) =>
           filePath = textEditor.getPath()
           json = []
+          hints = (('--hint=' + h) for h in @hlintHints)
           process = new BufferedProcess
             command: @executablePath
-            args: [filePath, '--json', '--hint=Default', '--hint=Dollar', '--hint=Generalise']
+            args: [filePath, '--json'].concat hints 
+            # args: [filePath, '--json', '--hint=Default', '--hint=Dollar', '--hint=Generalise']
             # args: [filePath, '--json']
             stdout: (data) ->
               json.push data

--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -38,8 +38,6 @@ module.exports =
           process = new BufferedProcess
             command: @executablePath
             args: [filePath, '--json'].concat hints 
-            # args: [filePath, '--json', '--hint=Default', '--hint=Dollar', '--hint=Generalise']
-            # args: [filePath, '--json']
             stdout: (data) ->
               json.push data
             exit: (code) ->


### PR DESCRIPTION
Hi, 

This PR makes the set of hints configurable by:

1. Exposing a parameter which is a list of strings (files),
2. The default yields the current behavior, namely `--hint=Default --hint=Dollar --hint=Generalise` 
3. Allows the user to specify their own files (e.g. to switch on _all_ hints, simply use `HLint`).

Thanks!

Ranjit.