### PR TITLE
Add a linter name

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -45,6 +45,7 @@ export default {
 
   provideLinter() {
     return {
+      name: 'HLint',
       grammarScopes: ['source.haskell', 'text.tex.latex.haskell'],
       scope: 'file',
       lintOnFly: false,


### PR DESCRIPTION
Specify the name so messages can be identified as coming from this linter provider.

Fixes #24.