### PR TITLE
Add ~/.ghc to Cabal cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,8 +15,8 @@ defaults: &defaults
     # Restore Cabal cache
     - restore_cache:
         keys:
-        # Get latest cache for this package.json
-        - v1-cabal-{{ arch }}-{{ checksum "package.json" }}
+        # Get latest cache for the current specs
+        - v1-cabal-{{ arch }}-{{ checksum "spec/linter-hlint-spec.js" }}
         # Fallback to the last available cache
         - v1-cabal-{{ arch }}
     - run:
@@ -81,12 +81,12 @@ defaults: &defaults
         paths:
           - node_modules
         key: v3-dependencies-{{ checksum "package.json" }}
-    # Cache Cabal
+    # Cache Cabal, keyed on the specs
     - save_cache:
         paths:
           - "~/.cabal"
           - "~/.ghc"
-        key: v1-cabal-{{ arch }}-{{ checksum "package.json" }}
+        key: v1-cabal-{{ arch }}-{{ checksum "spec/linter-hlint-spec.js" }}
 
 jobs:
   checkout_code:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,6 +85,7 @@ defaults: &defaults
     - save_cache:
         paths:
           - "~/.cabal"
+          - "~/.ghc"
         key: v1-cabal-{{ arch }}-{{ checksum "package.json" }}
 
 jobs:


### PR DESCRIPTION
It turns out that although 99.9% of the files are under `~/.cabal`, they are completely useless without the files under `~/.ghc` and are ignored. Add `~/.ghc` to the cache to allow these files to be used as well.